### PR TITLE
Allows for clicking on nested DOM elements within each .text-suggestion (custom render + autoComplete plugin)

### DIFF
--- a/src/js/textext.plugin.autocomplete.js
+++ b/src/js/textext.plugin.autocomplete.js
@@ -338,8 +338,11 @@
 		var self   = this,
 			target = $(e.target)
 			;
+			
+	  if(!target.is(CSS_DOT_SUGGESTION))
+		  target = target.parents(CSS_DOT_SUGGESTION)[0];
 
-		if(target.is(CSS_DOT_SUGGESTION))
+		if(target)
 		{
 			self.clearSelected();
 			target.addClass(CSS_SELECTED);
@@ -363,7 +366,10 @@
 			target = $(e.target)
 			;
 
-		if(target.is(CSS_DOT_SUGGESTION))
+		if(!target.is(CSS_DOT_SUGGESTION))
+		  target = target.parents(CSS_DOT_SUGGESTION)[0];
+		
+		if (target)
 			self.selectFromDropdown();
 	};
 


### PR DESCRIPTION
When using a custom `render()` method containing more than 1 level of
nesting, the `onClick` event is not triggered when not clicking
_directly_ on the root `.text-suggestion` element.
- http://goo.gl/MpY8f

Clicking anywhere in the green box will not trigger the `onClick`.
Clicking in the red box _(a small sliver at the bottom of the
`.text-suggestion`)_ **does** trigger the `onClick`.

This changeset causes the `onMouseOver` and `onClick` events to look at
the `target`'s ancestor's to see if one of them is a `.text-suggestion`,
swapping the `target` to that DOM element if found.
