### PR TITLE
Fixes getter methods created when plugins are initialized.

### DIFF
--- a/src/js/textext.core.js
+++ b/src/js/textext.core.js
@@ -802,7 +802,9 @@
 			if(plugin)
 			{
 				self._plugins[name] = plugin = new plugin();
-				self[name] = function() { return plugin; };
+				self[name] = (function(plugin) { 
+				  return function(){ return plugin; } 
+				})(plugin);
 				initList.push(plugin);
 				$.extend(true, plugin, self.opts(OPT_EXT + '.*'), self.opts(OPT_EXT + '.' + name));
 			}


### PR DESCRIPTION
Because the following function definition is not wrapped in a closure

```
self[name] = function() { return plugin; };
```

`plugin`'s scope is the `TextExt.initPlugins` function. Because of this,
on each iteration of the list of plugins to create the getter methods in
`TextExt`, the return value of all created methods will be the last
value of `plugin` and not the value of `plugin` from when the function
was defined for each.

Wrapping the function definition in a closure fixes this issue.

As an explicit example:

Previously, when instantiating a new `textext(...)` instance and
defining the `plugins` option as

```
plugins: 'autocomplete arrow'
```

All 3 of the following would return the `TextExtArrow` instance

```
$('...').textext()[0].ie9();
$('...').textext()[0].autocomplete();
$('...').textext()[0].arrow();
```

After they closure from this changeset is applied, they return their
expected plugin instances

```
 $('...').textext()[0].ie9();          // TextExtIE9Patches
 $('...').textext()[0].autocomplete(); // TextExtAutocomplete
 $('...').textext()[0].arrow();        // TextExtArrow
```
