### PR TITLE
Fix for issue #29

### DIFF
--- a/src/js/textext.core.js
+++ b/src/js/textext.core.js
@@ -688,6 +688,8 @@
 		container         = $(self.opts(OPT_HTML_WRAP));
 		hiddenInput       = $(self.opts(OPT_HTML_HIDDEN));
 
+		self.originalWidth = input.outerWidth();
+		
 		input
 			.wrap(container)
 			.keydown(function(e) { return self.onKeyDown(e) })
@@ -712,7 +714,6 @@
 		$.extend(true, itemManager, self.opts(OPT_EXT + '.item.manager'));
 		$.extend(true, self, self.opts(OPT_EXT + '.*'), self.opts(OPT_EXT + '.core'));
 		
-		self.originalWidth = input.outerWidth();
 
 		self.invalidateBounds();
 


### PR DESCRIPTION
Calculates the width before making changes to the input. This calculates the width correctly.

(As it is, it gets 0px for width() + 12px in borders/margins etc.)
