### PR TITLE
allow user click item for adding it when autocomplete custom render return html not simple text

### DIFF
--- a/src/js/textext.plugin.autocomplete.js
+++ b/src/js/textext.plugin.autocomplete.js
@@ -347,7 +347,7 @@
 	p.onMouseOver = function(e)
 	{
 		var self   = this,
-			target = $(e.target)
+			target = $(e.target).closest(CSS_DOT_SUGGESTION);
 			;
 
 		if(target.is(CSS_DOT_SUGGESTION))
@@ -387,7 +387,7 @@
 	p.onClick = function(e)
 	{
 		var self   = this,
-			target = $(e.target).closest('.text-label')
+			target = $(e.target).closest(CSS_DOT_LABEL)
 			;
 
 		if(target.is(CSS_DOT_SUGGESTION) || target.is(CSS_DOT_LABEL))

--- a/src/js/textext.plugin.autocomplete.js
+++ b/src/js/textext.plugin.autocomplete.js
@@ -387,7 +387,7 @@
 	p.onClick = function(e)
 	{
 		var self   = this,
-			target = $(e.target)
+			target = $(e.target).closest('.text-label')
 			;
 
 		if(target.is(CSS_DOT_SUGGESTION) || target.is(CSS_DOT_LABEL))


### PR DESCRIPTION
allow user click item for adding it when autocomplete custom render return html not simple text

for example,if json is not string array,but a tuple array:
[{"label":"label for value1","value":"value1"},{"label":"label for value2","value":"value2"}]

``` js
render : function(suggestion) {
if (typeof suggestion == 'string') {
return suggestion;
} else {
if (!suggestion.label)
return suggestion.value;
else
return '<div value="' + suggestion.value + '">'+ suggestion.label + '</div>';
}
}
```
