### PR TITLE
Fix bug with selecting and moving cursor within text input: don't setInputData unless value changed.

### DIFF
--- a/src/js/textext.core.js
+++ b/src/js/textext.core.js
@@ -1123,7 +1123,9 @@
 	 */
 	p.onSetInputData = function(e, data)
 	{
-		this.input().val(data);
+		if (this.input().val() != data) {
+			this.input().val(data);
+		}
 	};
 
 	/**


### PR DESCRIPTION
When using a text input rather than textarea, updating the value moves
the cursor to the end of the line. Since core triggers setInputData on
every keystroke, this makes it impossible to highlight, copy, paste, or
move the cursor within the text.

Fix by only updating the value if it has changed.

I believe this also fixes the following known issue:
http://github.com/alexgorbatchev/jquery-textext/issues/50
