### PR TITLE
calculate outerWidth before wrapping the input element

### DIFF
--- a/src/js/textext.core.js
+++ b/src/js/textext.core.js
@@ -694,6 +694,7 @@
 			.keyup(function(e) { return self.onKeyUp(e) })
 			.data('textext', self)
 			;
+		self.originalWidth = input.outerWidth();
 
 		// keep references to html elements using jQuery.data() to avoid circular references
 		$(self).data({
@@ -712,8 +713,6 @@
 		$.extend(true, itemManager, self.opts(OPT_EXT + '.item.manager'));
 		$.extend(true, self, self.opts(OPT_EXT + '.*'), self.opts(OPT_EXT + '.core'));
 		
-		self.originalWidth = input.outerWidth();
-
 		self.invalidateBounds();
 
 		itemManager.init(self);


### PR DESCRIPTION
In some cases, like when the input element is given a percentage width, wrapping the element makes `.outerWidth()` return 0 (or 2px, if it has a 1px border).  Calculating the original width before wrapping the element prevents this.
