### PR TITLE
Fixed infinite loop: Github issue 104.

### DIFF
--- a/src/js/textext.plugin.tags.js
+++ b/src/js/textext.plugin.tags.js
@@ -625,9 +625,13 @@
 			i, item
 			;
 
-		for(i = 0; i < list.length, item = $(list[i]); i++)
+		for(i = 0; i < list.length; i++) {
+			item = $(list[i]);
 			if(self.itemManager().compareItems(item.data(CSS_TAG), tag))
 				return item;
+		}
+		
+		return null;
 	};
 
 	/**
@@ -657,6 +661,10 @@
 		else
 		{
 			element = self.getTagElement(tag);
+			if (element === null) {
+				//Tag does not exist
+				return;
+			}
 		}
 
 		element.remove();


### PR DESCRIPTION
I fixed the small infinite loop issue reference in issue 104. I changed the for loop to not run if the list is empty, returning null instead. I also made a small modification to the removeTag() function to handle the case when the tag does not exist.
