### PR TITLE
Textarea & Cursor issue with IE 10

### DIFF
--- a/src/js/textext.plugin.tags.js
+++ b/src/js/textext.plugin.tags.js
@@ -671,6 +671,11 @@
 		self.updateFormCache();
 		core.getFormData();
 		core.invalidateBounds();
+
+        //Update input value for fix IE10 problem with padding.
+        var val = " " + self.input().val();
+        self.input().val(val);
+        self.input().val(val.slice(1));
 	};
 
 	/**


### PR DESCRIPTION
Hello,

I commit a trick to solve #94.

In IE10, if you have a textarea with fixed width and box-sizing: border-box and you reduce the padding, the control doesn't update this position automatically, then, I put a code to add, and remove a whitespace, then, cursor take the correct position.
