### PR TITLE
tagPreRender & tagRemove events in tags plugin

### DIFF
--- a/src/js/textext.plugin.tags.js
+++ b/src/js/textext.plugin.tags.js
@@ -182,6 +182,28 @@
 		 */
 		EVENT_TAG_PRE_RENDER = 'tagPreRender',
 
+		/**
+		 * Tags plugin triggers the `tagRemove` event just before the tag is going to be removed. This allows to 
+		 * attach other hooks which can potentially update some elements which are logically tied with the presence
+		 * of a particular tag.
+		 *
+		 *     $('textarea').textext({...}).bind('tagPreRender', function(e, tag, element)
+		 *     {
+		 *         if(tag.value == 'INDIA' || tag.value == 'CHINA')
+		 *				graph.removeStatsOfCountry(tag.value)
+		 *     })
+		 *
+		 * `tag` parameter is in the format that the current `ItemManager` can understand. Default is `String`.
+		 * `element` parameter is the jQuery object representing the DOM element for the corresponding tag.
+		 *
+		 * @name tagRemove
+		 * @version 1.3.0
+		 * @author abhishek shrivastava
+		 * @date 2013/11/19
+		 * @id TextExtTags.events.tagRemove
+		 */
+		EVENT_TAG_REMOVE = 'tagRemove',
+
 
 		DEFAULT_OPTS = {
 			tags : {
@@ -692,6 +714,8 @@
 				return;
 			}
 		}
+
+		this.trigger(EVENT_TAG_REMOVE, tag, element);
 
 		element.remove();
 		self.updateFormCache();

--- a/src/js/textext.plugin.tags.js
+++ b/src/js/textext.plugin.tags.js
@@ -157,6 +157,32 @@
 		 */
 		EVENT_TAG_CLICK = 'tagClick',
 
+		/**
+		 * Tags plugin triggers the `tagPreRender` event just before the tag is going to be rendered. This allows to 
+		 * potentially change the value of the tag which it recieves from another plugin say - Suggestions plugin. 
+		 * For example, when you want a value to be displayed in autocomplete suggestions dropdown but rendered differently  
+		 * as a tag after the user clicks on it.
+		 *
+		 * To change the value of the tag, simply update the `value` field of second argument to a new value. Example:
+		 *
+		 *     $('textarea').textext({...}).bind('tagPreRender', function(e, data)
+		 *     {
+		 *         var newvalue = data.value.toLowerCase();
+		 *		   data.value = newvalue;
+		 *     })
+		 *
+		 * The second argument `data` has the following format: `{ tag : {Object}, value : {String} }`. `tag`
+		 * property is in the format that the current `ItemManager` can understand. Default is `String`.
+		 *
+		 * @name tagPreRender
+		 * @version 1.3.0
+		 * @author abhishek shrivastava
+		 * @date 2013/11/19
+		 * @id TextExtTags.events.tagPreRender
+		 */
+		EVENT_TAG_PRE_RENDER = 'tagPreRender',
+
+
 		DEFAULT_OPTS = {
 			tags : {
 				enabled : true,
@@ -690,9 +716,12 @@
 		var self = this,
 			node = $(self.opts(OPT_HTML_TAG))
 			;
+		var opts = {tag: tag, value: self.itemManager().itemToString(tag)};
 
-		node.find('.text-label').text(self.itemManager().itemToString(tag));
-		node.data(CSS_TAG, tag);
+		this.trigger(EVENT_TAG_PRE_RENDER, opts);
+
+		node.find('.text-label').text(opts.value);
+		node.data(CSS_TAG, opts.tag);
 		return node;
 	};
 })(jQuery);


### PR DESCRIPTION
# tagPreRender

Adding a tagPreRender event in tags plugin that triggers just before a tag is going to be rendered, allowing ability to change the value of the tag to be displayed.

This is very useful in cases where you cannot change the value of the tag at the source because: a) Its value is shared with some other plugin, say - suggestions or autocomplete, b) ItemManager also cannot be used as you want to do this special treatment of the value just for tags.

Example - In the autocomplete, you want the suggestions to appear as "Name: Description", but when the user clicks on it and a tag is generated, it should only have "Name" in the tag.
# tagRemove

This is a very basic event which gets triggered just before the tag is going to be removed. Useful when there are other elements in the page which are dependent on a particular tag, and so when the tag gets removed, a hook added by you can capture this event which would enable you to update other dependent elements.
