### PR TITLE
With autocomplete & ajax, two ajax calls are sent.

### DIFF
--- a/src/js/textext.plugin.autocomplete.js
+++ b/src/js/textext.plugin.autocomplete.js
@@ -763,7 +763,7 @@
 			suggestions = self._suggestions
 			;
 
-		if(!suggestions)
+		if(!suggestions && !self.core().hasPlugin('ajax'))
 			return self.trigger(EVENT_GET_SUGGESTIONS);
 
 		if($.isFunction(renderCallback))


### PR DESCRIPTION
Fix for the issue #145.

When the autocomplete and ajax plugins are enabled, two ajax calls were sent after the first keyword events. In the second, the query was empty. So the list appeared and then disappeared.
