### PR TITLE
Added trigger for removing of a tag

### DIFF
--- a/src/js/textext.plugin.tags.js
+++ b/src/js/textext.plugin.tags.js
@@ -668,6 +668,10 @@
 		}
 
 		element.remove();
+
+	    // reference: http://stackoverflow.com/a/18953022
+		self.trigger('tagRemoved', element, tag);
+
 		self.updateFormCache();
 		core.getFormData();
 		core.invalidateBounds();


### PR DESCRIPTION
When the removeTag function is called and right after the element is
removed a trigger of 'tagRemoved' is called.  This will allow one to be
able to capture the removing of a tag and to be able to handle this case
dynamically.
