### PR TITLE
Suggestions list is not being correctly refreshed

### DIFF
--- a/src/js/textext.plugin.arrow.js
+++ b/src/js/textext.plugin.arrow.js
@@ -97,6 +97,7 @@
 	p.onArrowClick = function(e)
 	{
 		this.trigger('toggleDropdown');
+		this.trigger('getSuggestions', { query: this.val() });
 		this.core().focusInput();
 	};
 	


### PR DESCRIPTION
When you will enter some tag which is not on suggestions list and just after that you'll click arrow button, suggestions list stays empty.
This fixes this issue by enforcing suggestions list refresh every time when arrow will be clicked.
