### PR TITLE
enable hidden input to trigger change() observer

### DIFF
--- a/src/js/textext.core.js
+++ b/src/js/textext.core.js
@@ -1142,7 +1142,10 @@
 	p.onSetFormData = function(e, data)
 	{
 		var self = this;
-		self.hiddenInput().val(self.serializeData(data));
+		if (self.hiddenInput().val() !== self.serializeData(data))
+		{
+			self.hiddenInput().val(self.serializeData(data)).change();
+		}
 	};
 
 	/**


### PR DESCRIPTION
hidden input fields don't trigger the change() event.

For users who may just want to observe changes to the hidden input value and respond to it e.g.

``` js
$("input[type=hidden]").bind("change", function() {
    console.log($(this).val()); 
 });
```

This fix force-triggers the change() event and also only sets the value (and therefore the change) when the input value has changed.
